### PR TITLE
add the possibility to provider a prepared .google_authenticator

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -4,6 +4,10 @@
 [[ -e /authorized_keys ]] \
 	&& cp /authorized_keys /bastion/ \
 	&& chown bastion:users /bastion/authorized_keys
-
+[[ -e /.google_authenticator ]] \
+	&& cp /.google_authenticator /bastion/ \
+	&& chown bastion:users /bastion/.google_authenticator \
+	&& chmod 0400 /bastion/.google_authenticator
+	
 ssh-keygen -A \
 && exec /usr/sbin/sshd -De -o LogLevel=$LOG_LEVEL


### PR DESCRIPTION
This allows the user to provide a previously prepared .google_authenticator file to the image. 