### PR TITLE
Add openssh-client package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN echo '[[ -e .google_authenticator ]] || google-authenticator' >> /etc/profil
 
 RUN apk add \
 	google-authenticator \
-	openssh-server-pam
+	openssh-server-pam \
+	openssh-client
 RUN rm -f \
 	/etc/ssh/ssh_host_*_key* \
 	/etc/motd \


### PR DESCRIPTION
To use Bastion as a jump host and being able to connect to another SSH enabled device.